### PR TITLE
Fix 'Deprecated function: Implicit conversion from float to int loses precision'

### DIFF
--- a/src/SimpleXLS.php
+++ b/src/SimpleXLS.php
@@ -1001,7 +1001,7 @@ class SimpleXLS
                     //echo $numValue." ";
                     $t_alias = 'n';
                     if ($this->isDate($spos)) {
-                        [$string, $raw] = $this->createDate($numValue);
+                        [$string, $raw] = $this->createDate((int) $numValue);
                         $t_alias = 'd';
                     } else {
                         $raw = $numValue;
@@ -1033,7 +1033,7 @@ class SimpleXLS
                     for ($i = 0; $i < $columns; $i ++) {
                         $numValue = $this->_getIEEE754($this->_getInt4d($tmppos + 2));
                         if ($this->isDate($tmppos - 4)) {
-                            [$string, $raw] = $this->createDate($numValue);
+                            [$string, $raw] = $this->createDate((int) $numValue);
                             $t_alias = 'd';
                         } else {
                             $raw = $numValue;
@@ -1058,7 +1058,7 @@ class SimpleXLS
                     $tmp    = unpack('ddouble', substr($this->data, $spos + 6, 8)); // It machine machine dependent
                     $t_alias = 'n';
                     if ($this->isDate($spos)) {
-                        [$string, $raw] = $this->createDate($tmp['double']);
+                        [$string, $raw] = $this->createDate((int) $tmp['double']);
                         $t_alias = 'd';
                         //   $this->addcell(DateRecord($r, 1));
                     } else {
@@ -1097,7 +1097,7 @@ class SimpleXLS
                         // result is a number, so first 14 bytes are just like a _NUMBER record
                         $tmp = unpack('ddouble', substr($this->data, $spos + 6, 8)); // It machine machine dependent
                         if ($this->isDate($spos)) {
-                            [$string, $raw] = $this->createDate($tmp['double']);
+                            [$string, $raw] = $this->createDate((int) $tmp['double']);
                             //   $this->addcell(DateRecord($r, 1));
                         } else {
                             //$raw = $tmp[''];


### PR DESCRIPTION
The following deprecation notice appears when reading a spreadsheet in a webapp using PHP 8.1:

```
Deprecated function: Implicit conversion from float 45232.019615543984 to int loses precision in Shuchkin\SimpleXLS->createDate() (regel 1231 van [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php)

#0 [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php(1231): _wmsentry_error_handler_real()
#1 [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php(1061): Shuchkin\SimpleXLS->createDate()
#2 [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php(899): Shuchkin\SimpleXLS->_parseSheet()
#3 [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php(226): Shuchkin\SimpleXLS->_parse()
#4 [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php(239): Shuchkin\SimpleXLS->__construct()
#5 [..]/vendor/shuchkin/simplexls/src/SimpleXLS.php(230): Shuchkin\SimpleXLS::parse()
#6 [..]/public/modules/custom/site_module/src/Import/ImportBase.php(161): Shuchkin\SimpleXLS::parseFile()
```